### PR TITLE
Fix auto-boot by timeout while staying in System menu

### DIFF
--- a/src/kexecboot.c
+++ b/src/kexecboot.c
@@ -906,6 +906,7 @@ int process_ctx_menu(struct params_t *params, int action) {
 
 #ifdef USE_TIMEOUT
 	case A_TIMEOUT:		// timeout was reached - boot 1st kernel if exists
+		menu->current = menu->top;		/* go top-level menu */
 		if (menu->current->count > 1) {
 			menu_item_select(menu, 0);	/* choose first item */
 			menu_item_select(menu, 1);	/* and switch to next item */


### PR DESCRIPTION
Ensure to return to main menu before choosing kernel to auto-boot by
timeout.

Closes #17