### PR TITLE
Fix motorola power key that sends KEY_END instead of KEY_POWER

### DIFF
--- a/src/evdevs.c
+++ b/src/evdevs.c
@@ -316,6 +316,7 @@ int inputs_process_evdev(int fd)
 		case KEY_HENKAN:	/* Zaurus SL-6000 */
 		case 87:			/* Zaurus: OK (remove?) */
 		case 63:			/* Zaurus: Enter (remove?) */
+		case KEY_END:		/* Motorola Mapphone devices (107) */
 		case KEY_POWER:		/* GTA02: Power (116) */
 		case KEY_PHONE:		/* GTA02: AUX (169) */
 			action = A_SELECT;


### PR DESCRIPTION
Somehow motorola stock android kernel v3.0.8 sends KEY_END instead
of KEY_POWER when the power key is pressed. Let's add that as a
select key. Otherwise kexecboot cannot be used on devices like
mz617 that have no physical keyboard.

Cc: Carl Philipp Klemm <philipp@uvos.xyz>
Signed-off-by: Tony Lindgren <tony@atomide.com>