### PR TITLE
Fix compile on gcc 10+

### DIFF
--- a/src/fb.c
+++ b/src/fb.c
@@ -24,6 +24,7 @@
 
 #include "fb.h"
 
+FB fb;
 
 static unsigned int compose_color (kx_rgba rgba) {
 

--- a/src/fb.h
+++ b/src/fb.h
@@ -77,7 +77,7 @@ typedef struct FB {
 	draw_hline_func draw_hline;
 } FB;
 
-FB fb;
+extern FB fb;
 
 /* Picture structure */
 /* FIXME: store pixels as colors triplets per uint32_t value */

--- a/src/util.c
+++ b/src/util.c
@@ -33,6 +33,8 @@
 #include "util.h"
 
 
+kx_text *lg;
+
 /* Create charlist structure */
 struct charlist *create_charlist(int size)
 {

--- a/src/util.h
+++ b/src/util.h
@@ -71,7 +71,7 @@ typedef struct {
 } kx_text;
 
 /* Global log structure */
-kx_text *lg;
+extern kx_text *lg;
 
 /*
  * FUNCTIONS


### PR DESCRIPTION
Tested on GCC 11.1.0 and Redmi 2 (ARM64),Everything works.
There are some errors while compile on gcc 10+.
```
/usr/bin/ld: /usr/bin/ld: DWARF error: can't find .debug_ranges section.
kexecboot-cfgparser.o:(.bss+0x0): multiple definition of `lg'; /usr/bin/ld: DWARF error: can't find .debug_ranges section.
kexecboot-util.o:(.bss+0x0): first defined here
/usr/bin/ld: /usr/bin/ld: DWARF error: can't find .debug_ranges section.
kexecboot-devicescan.o:(.bss+0x0): multiple definition of `lg'; kexecboot-util.o:(.bss+0x0): first defined here
/usr/bin/ld: /usr/bin/ld: DWARF error: invalid or unhandled FORM value: 0x1e
kexecboot-evdevs.o:(.bss+0x0): multiple definition of `lg'; kexecboot-util.o:(.bss+0x0): first defined here
/usr/bin/ld: /usr/bin/ld: DWARF error: can't find .debug_ranges section.
kexecboot-fb.o:(.bss+0x90): multiple definition of `lg'; kexecboot-util.o:(.bss+0x0): first defined here
/usr/bin/ld: /usr/bin/ld: DWARF error: can't find .debug_ranges section.
kexecboot-gui.o:(.bss+0x0): multiple definition of `fb'; kexecboot-fb.o:(.bss+0x0): first defined here
/usr/bin/ld: kexecboot-gui.o:(.bss+0x90): multiple definition of `lg'; kexecboot-util.o:(.bss+0x0): first defined here
/usr/bin/ld: kexecboot-menu.o:/run/media/guo/0ed46c3d-c7db-4e08-80e2-4b18bd7544a2/home/guo/handsomepojects/kexecboot/src/menu.h:74: multiple definition of `lg'; kexecboot-util.o:(.bss+0x0): first defined here
/usr/bin/ld: kexecboot-xpm.o:/usr/lib/gcc/x86_64-pc-linux-gnu/11.1.0/include/stdint-uintn.h:74: multiple definition of `lg'; kexecboot-util.o:(.bss+0x0): first defined here
/usr/bin/ld: kexecboot-xpm.o:/run/media/guo/0ed46c3d-c7db-4e08-80e2-4b18bd7544a2/home/guo/handsomepojects/kexecboot/src/rgb.h:80: multiple definition of `fb'; kexecboot-fb.o:(.bss+0x0): first defined here
/usr/bin/ld: /usr/bin/ld: DWARF error: can't find .debug_ranges section.
kexecboot-rgb.o:(.bss+0x0): multiple definition of `lg'; kexecboot-util.o:(.bss+0x0): first defined here
/usr/bin/ld: /usr/bin/ld: DWARF error: can't find .debug_ranges section.
kexecboot-kexecboot.o:(.bss+0xb0): multiple definition of `lg'; kexecboot-util.o:(.bss+0x0): first defined here
/usr/bin/ld: kexecboot-kexecboot.o:(.bss+0x20): multiple definition of `fb'; kexecboot-fb.o:(.bss+0x0): first defined here
```