### PR TITLE
Revert "Fix compile on gcc 10+"

### DIFF
--- a/src/fb.c
+++ b/src/fb.c
@@ -24,7 +24,6 @@
 
 #include "fb.h"
 
-FB fb;
 
 static unsigned int compose_color (kx_rgba rgba) {
 

--- a/src/util.c
+++ b/src/util.c
@@ -33,8 +33,6 @@
 #include "util.h"
 
 
-kx_text *lg;
-
 /* Create charlist structure */
 struct charlist *create_charlist(int size)
 {


### PR DESCRIPTION
Reverts kexecboot/kexecboot#20

Somehow it breaks compilation on x86..