### PR TITLE
make: Add compiler includes in cflags

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,6 @@
 bin_PROGRAMS=kexecboot
 
-kexecboot_CFLAGS = -I$(top_srcdir) $(AM_CFLAGS)
+kexecboot_CFLAGS = -I$(top_srcdir) $(AM_CFLAGS) -I$(shell $(CC) -print-file-name=include)
 
 kexecboot_SOURCES = \
 	global.c \


### PR DESCRIPTION
Fixes
| In file included from /mnt/b/yoe/master/build/tmp/work/raspberrypi4_64-yoe-linux/kexecboot-klibc/0.6+gitAUTOINC+5a5e04be20-r0/recipe-sysroot/usr/lib/klibc/include/stdio.h:11: | /mnt/b/yoe/master/build/tmp/work/raspberrypi4_64-yoe-linux/kexecboot-klibc/0.6+gitAUTOINC+5a5e04be20-r0/recipe-sysroot/usr/lib/klibc/include/stdarg.h:9:15: fatal error: 'stdarg.h' file not found | #include_next <stdarg.h>
|               ^~~~~~~~~~

Thanks to Khem Raj who did this patch originally: https://git.openembedded.org/meta-openembedded/tree/meta-initramfs/recipes-bsp/kexecboot/files/0001-make-Add-compiler-includes-in-cflags.patch?h=honister