### PR TITLE
Fix argument errors in gcc 15

### DIFF
--- a/src/fb.c
+++ b/src/fb.c
@@ -388,7 +388,7 @@ void fb_restore(char *dump)
 }
 
 
-void fb_destroy()
+void fb_destroy(FB fb)
 {
 	if (fb.fd >= 0)
 		close(fb.fd);
@@ -651,7 +651,7 @@ int fb_new(int angle)
 	return 0;
 
 fail:
-	fb_destroy();
+	fb_destroy(fb);
 	return -1;
 }
 

--- a/src/fb.h
+++ b/src/fb.h
@@ -88,7 +88,7 @@ typedef struct {
 } kx_picture;
 
 
-void fb_destroy();
+void fb_destroy(FB fb);
 
 int fb_new(int angle);
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -157,7 +157,7 @@ void gui_destroy(struct gui_t *gui)
 	free(gui->icons);
 #endif
 
-	fb_destroy();
+	fb_destroy(fb);
 	free(gui);
 }
 

--- a/src/tui.h
+++ b/src/tui.h
@@ -33,7 +33,7 @@ typedef struct {
 } kx_tui;
 
 
-kx_tui *tui_init();
+kx_tui *tui_init(FILE *ts);
 
 void tui_show_menu(kx_tui *tui, kx_menu *menu);
 


### PR DESCRIPTION
* fix following errors
```
../../git/src/fb.c: In function 'fb_new':
../../git/src/fb.c:646:17: error: too many arguments to function 'fb_destroy'; expected 0, have 1
  646 |                 fb_destroy(fb);
      |                 ^~~~~~~~~~ ~~
../../git/src/fb.c:391:6: note: declared here
  391 | void fb_destroy()
      |      ^~~~~~~~~~
../../git/src/tui.c:102:9: error: conflicting types for 'tui_init'; have 'kx_tui *(FILE *)'
  102 | kx_tui *tui_init(FILE *ts)
      |         ^~~~~~~~
In file included from ../../git/src/tui.c:40:
../../git/src/tui.h:36:9: note: previous declaration of 'tui_init' with type 'kx_tui *(void)'
   36 | kx_tui *tui_init();
...
```